### PR TITLE
Introduce flexibility to dependency version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,16 @@ authors = [
     { name = "LAION-AI", email = "contact@laion.ai" }
 ]
 dependencies = [
-    "datasets==2.11.0",
-    "torch==2.0.0",
-    "transformers==4.27.4",
-    "hydra-core==1.3.2",
-    "tokenizers==0.13.2",
+    "datasets>=2.11.0",
+    "torch>=2.0.0",
+    "transformers>=4.27.4",
+    "hydra-core>=1.3.2",
+    "tokenizers>=0.13.2",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "wandb==0.14.0",
+    "wandb>=0.14.0",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-datasets==2.11.0
-torch==2.0.0
-transformers==4.27.4
-hydra-core==1.3.2
-tokenizers==0.13.2
-wandb==0.14.0
+datasets>=2.11.0
+torch>=2.0.0
+transformers>=4.27.4
+hydra-core>=1.3.2
+tokenizers>=0.13.2
+wandb>=0.14.0


### PR DESCRIPTION
For now I haven't looked into whether we could also lower the required versions, but this change should be sufficient to allow `blade2blade` to be compatible with the Open Assistant inference worker (which uses a newer version of `transformers` than `4.27.4`)